### PR TITLE
Py3 convert

### DIFF
--- a/build_papers.py
+++ b/build_papers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 # Schedule some or all papers for build
 
@@ -11,7 +12,7 @@ else:
     to_build = [nr for nr, info in papers]
 
 for p in to_build:
-    print "Placing %s in the build queue." % p
+    print("Placing %s in the build queue." % p)
     paper_queue[0].put(int(p))
     paper_queue[1] += 1
 

--- a/procbuild/__init__.py
+++ b/procbuild/__init__.py
@@ -10,36 +10,8 @@ ALLOW_MANUAL_BUILD_TRIGGER = bool(int(os.environ.get(
 __all__ = ['app', 'log', 'MASTER_BRANCH', 'papers', 'paper_queue']
 
 
-import json
-
-from os.path import join as joinp
-from time import gmtime, strftime
-from multiprocessing import Queue
-
-from .pr_list import update_papers, pr_list_file
-from . import server
-
-app = server.app
-
-logfile = open(joinp(os.path.dirname(__file__), '../flask.log'), 'w')
+from .server import app, log, papers, paper_queue
 
 
-def log(message):
-    print(message)
-    logfile.write(strftime("%Y-%m-%d %H:%M:%S", gmtime()) + " " +
-                  message + '\n')
-    logfile.flush()
-
-
-if not os.path.isfile(pr_list_file):
-    update_papers()
-
-with open(pr_list_file) as f:
-    pr_info = json.load(f)
-    papers = [(str(n), pr) for n, pr in enumerate(pr_info)]
-
-print("Setting up build queue...")
-paper_queue_size = 0
-paper_queue = {0:Queue(), 1:paper_queue_size}
 
 server.monitor_queue()

--- a/procbuild/__init__.py
+++ b/procbuild/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 # --- Customize these variables ---
 import os
 MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2016')
@@ -11,18 +12,16 @@ __all__ = ['app', 'log', 'MASTER_BRANCH', 'papers', 'paper_queue']
 
 from flask import Flask
 
-import os
-from os.path import join as joinp
-from time import gmtime, strftime
-
-from pr_list import update_papers, pr_list_file
 import json
 
+from os.path import join as joinp
+from time import gmtime, strftime
 from multiprocessing import Queue
 
+from .pr_list import update_papers, pr_list_file
+from . import server
 
 app = Flask(__name__)
-
 
 logfile = open(joinp(os.path.dirname(__file__), '../flask.log'), 'w')
 
@@ -41,9 +40,8 @@ with open(pr_list_file) as f:
     pr_info = json.load(f)
     papers = [(str(n), pr) for n, pr in enumerate(pr_info)]
 
-print "Setting up build queue..."
+print("Setting up build queue...")
 paper_queue_size = 0
 paper_queue = {0:Queue(), 1:paper_queue_size}
 
-import server
 server.monitor_queue()

--- a/procbuild/__init__.py
+++ b/procbuild/__init__.py
@@ -10,8 +10,6 @@ ALLOW_MANUAL_BUILD_TRIGGER = bool(int(os.environ.get(
 __all__ = ['app', 'log', 'MASTER_BRANCH', 'papers', 'paper_queue']
 
 
-from flask import Flask
-
 import json
 
 from os.path import join as joinp
@@ -21,7 +19,7 @@ from multiprocessing import Queue
 from .pr_list import update_papers, pr_list_file
 from . import server
 
-app = Flask(__name__)
+app = server.app
 
 logfile = open(joinp(os.path.dirname(__file__), '../flask.log'), 'w')
 

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 import tempfile
 import subprocess
 import shlex
@@ -9,7 +11,7 @@ import time
 import random
 from os.path import join as joinp
 
-from futil import age as file_age, base_path
+from .futil import age as file_age, base_path
 
 excluded = ['vanderwalt','00_vanderwalt','jane_doe','bibderwalt','00_intro']
 
@@ -29,7 +31,7 @@ def repo(user='scipy'):
 
 
 def error(msg):
-    print msg
+    print(msg)
 
 
 def shell(cmd, path=None, retry=0):

--- a/procbuild/pr_list.py
+++ b/procbuild/pr_list.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 __all__ = ['fetch_PRs', 'update_papers']
 
 import urllib3
@@ -7,7 +9,7 @@ import os
 from os.path import join as joinp
 
 
-from builder import cache
+from .builder import cache
 pr_list_file = joinp(cache(), 'pr_info.json')
 
 
@@ -30,7 +32,7 @@ def fetch_PRs(user, repo, state='open'):
     while page_data:
         fetch_status = 'Fetching page %(page)d (state=%(state)s)' % fields + \
                        ' from %(user)s/%(repo)s...' % config
-        print fetch_status
+        print(fetch_status)
 
         response = http.request('GET', url, fields=fields,
                                 headers={'user-agent': 'scipy-procbuild/0.1'})
@@ -41,7 +43,7 @@ def fetch_PRs(user, repo, state='open'):
 
         if 'message' in page_data and page_data['message'] == "Not Found":
             page_data = []
-            print 'Warning: Repo not found (%(user)s/%(repo)s)' % config
+            print('Warning: Repo not found (%(user)s/%(repo)s)' % config)
         else:
             data.extend(page_data)
 

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -1,5 +1,5 @@
-from procbuild import (app, log, papers, pr_info, paper_queue,
-                       MASTER_BRANCH, ALLOW_MANUAL_BUILD_TRIGGER)
+from __future__ import print_function, absolute_import 
+
 
 from flask import (render_template, url_for, send_file, jsonify,
                    request)
@@ -7,13 +7,15 @@ import json
 import os
 from os.path import join as joinp
 from glob import glob
-from futil import age as file_age, base_path
 import time
 
-from builder import build as build_paper, cache
 from multiprocessing import Process
-from pr_list import update_papers, pr_list_file
 
+from .procbuild import (app, log, papers, pr_info, paper_queue,
+                       MASTER_BRANCH, ALLOW_MANUAL_BUILD_TRIGGER)
+from .builder import build as build_paper, cache
+from .pr_list import update_papers, pr_list_file
+from .futil import age as file_age, base_path
 
 def status_file(nr):
     return joinp(cache(), str(nr) + '.status')

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import
 
 
 from flask import (render_template, url_for, send_file, jsonify,
-                   request)
+                   request, Flask)
 import json
 import os
 from os.path import join as joinp
@@ -11,11 +11,14 @@ import time
 
 from multiprocessing import Process
 
-from .procbuild import (app, log, papers, pr_info, paper_queue,
+from procbuild import (app, log, papers, pr_info, paper_queue,
                        MASTER_BRANCH, ALLOW_MANUAL_BUILD_TRIGGER)
 from .builder import build as build_paper, cache
 from .pr_list import update_papers, pr_list_file
 from .futil import age as file_age, base_path
+
+from flask import Flask
+app = Flask(__name__)
 
 def status_file(nr):
     return joinp(cache(), str(nr) + '.status')
@@ -80,7 +83,7 @@ def _process_queue(queue):
             _build_worker(nr)
 
 def monitor_queue():
-    print "Launching queue monitoring process..."
+    print("Launching queue monitoring process...")
     p = Process(target=_process_queue, kwargs=dict(queue=paper_queue[0]))
     p.start()
 

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -11,7 +11,7 @@ import time
 
 from multiprocessing import Process
 
-from procbuild import (app, log, papers, pr_info, paper_queue,
+from procbuild import (log, papers, pr_info, paper_queue,
                        MASTER_BRANCH, ALLOW_MANUAL_BUILD_TRIGGER)
 from .builder import build as build_paper, cache
 from .pr_list import update_papers, pr_list_file

--- a/runserver.py
+++ b/runserver.py
@@ -15,8 +15,8 @@ for (key, val) in config:
 from procbuild import app
 from waitress import serve
 
-serve(app, host='0.0.0.0', port=6000)
+serve(app, host='0.0.0.0', port=5000)
 
 # Without waitress, this is the call:
 #
-# app.run(debug=False, host='0.0.0.0', port=6000)
+# app.run(debug=False, host='0.0.0.0', port=5000)

--- a/runserver.py
+++ b/runserver.py
@@ -15,8 +15,8 @@ for (key, val) in config:
 from procbuild import app
 from waitress import serve
 
-serve(app, host='0.0.0.0', port=5000)
+serve(app, host='0.0.0.0', port=6000)
 
 # Without waitress, this is the call:
 #
-# app.run(debug=False, host='0.0.0.0', port=5000)
+# app.run(debug=False, host='0.0.0.0', port=6000)


### PR DESCRIPTION
This should make the server python 2/3 compatible. 

biggest change that needed to occur was shifting around the declaration of a bunch of things out of the `__init__.py` because that was introducing a circular dependency once we were using py2/3 compatible relative imports (and forcing absolute imports).