### PR TITLE
Py3 convert

### DIFF
--- a/procbuild/__init__.py
+++ b/procbuild/__init__.py
@@ -9,9 +9,4 @@ ALLOW_MANUAL_BUILD_TRIGGER = bool(int(os.environ.get(
 
 __all__ = ['app', 'log', 'MASTER_BRANCH', 'papers', 'paper_queue']
 
-
-from .server import app, log, papers, paper_queue
-
-
-
-server.monitor_queue()
+from .server import app, log, papers, paper_queue, monitor_queue

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -34,6 +34,16 @@ def error(msg):
     print(msg)
 
 
+def decode_output(f):
+    def wrapped_f(*args, **kwargs):
+        err, out = f(*args, **kwargs)
+        out = out.decode('utf-8')
+        return err, out
+
+    return wrapped_f
+
+
+@decode_output
 def shell(cmd, path=None, retry=0):
     """
     Raises
@@ -41,7 +51,7 @@ def shell(cmd, path=None, retry=0):
     CalledProcessError (has .returncode, .output parameter)
     """
     returncode = 0
-    output = ''
+    output = b''
     for i in range(retry + 1):
         try:
             return 0, subprocess.check_output(shlex.split(cmd), cwd=path,
@@ -50,19 +60,19 @@ def shell(cmd, path=None, retry=0):
             if not isinstance(e.output, list):
                 e.output = [e.output]
             returncode = e.returncode
-            output += '\n'.join(e.output)
+            output += b'\n'.join(e.output)
         except OSError as e:
-            if not 'Resource temporarily unavailable' in e.strerror:
-                return 1, e.strerror + '\n';
+            if not b'Resource temporarily unavailable' in e.strerror:
+                return 1, e.strerror + b'\n';
             else:
-                output += '\n' + e.strerror
+                output += b'\n' + e.strerror
 
         if i < retry:
             delay = random.randint(5, 10)
-            output += '\nRetrying after %ds...\n' % delay
+            output += b'\nRetrying after %ds...\n' % delay
             time.sleep(delay)
 
-    return returncode, output.strip() + '\n'
+    return returncode, output.strip() + b'\n'
 
 
 def checkout(repo, branch, build_path):

--- a/procbuild/pr_list/__init__.py
+++ b/procbuild/pr_list/__init__.py
@@ -39,7 +39,7 @@ def fetch_PRs(user, repo, state='open'):
 
         fields['page'] += 1
 
-        page_data = json.loads(response.data)
+        page_data = json.loads(response.data.decode('utf-8'))
 
         if 'message' in page_data and page_data['message'] == "Not Found":
             page_data = []

--- a/procbuild/pr_list/__init__.py
+++ b/procbuild/pr_list/__init__.py
@@ -27,7 +27,7 @@ def fetch_PRs(user, repo, state='open'):
     page_data = True
     
     url = 'https://api.github.com/repos/{user:s}/{repo:s}/pulls'.format(**config)
-    http = urllib3.PoolManager()
+    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
 
     while page_data:
         fetch_status = 'Fetching page {page:d} (state={state:s})'.format(**fields) + \

--- a/runserver.py
+++ b/runserver.py
@@ -2,7 +2,7 @@
 
 # -- SERVER CONFIGURATION -- (can be overridden from shell)
 
-config = (('MASTER_BRANCH', '2016'),
+config = (('MASTER_BRANCH', '2017'),
           ('ALLOW_MANUAL_BUILD_TRIGGER', '1'))
 
 # -- END SERVER CONFIGURATION --
@@ -12,9 +12,11 @@ for (key, val) in config:
     if not key in os.environ:
         os.environ[key] = val
 
-from procbuild import app
+from procbuild import app, monitor_queue
 from waitress import serve
 
+print('Monitoring build queue...')
+monitor_queue()
 serve(app, host='0.0.0.0', port=7000)
 
 # Without waitress, this is the call:


### PR DESCRIPTION
Lots of help from @stefanv and @Carreau finishing up the py3 conversion. 

Note, now if you want to start the queue, you will have to use

```python 
import monitor_queue from procbuild.server
monitor_queue()
```

rather than expecting it to work on importing `procbuild`. Honestly, I think that's cleaner anyway, since otherwise there will be no way to execute submodules with `__main__.py`s because it will run the   `__init__.py` and the loop through the queue will never exit. I still need to figure out what _exactly_ makes it so that the queue exits in one case but not the other, but for now this works.

Also, the way the queue is being handled we couldn't figure out how `build_papers.py` ever worked, but that's more for debugging than the most common use case anyway. 

But in summary: it looks like we finally have a fully functional version of this server on python3!