### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:17.10
+
+RUN apt-get update && \
+    apt-get install -y python3.6 python3.6-venv git curl \
+    texlive-latex-base texlive-publishers texlive-fonts-recommended  \
+    texlive-latex-extra texlive-bibtex-extra && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    useradd --create-home --shell /bin/bash procbuild
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+ADD . /procbuild
+WORKDIR /procbuild
+
+RUN bash -c "python3.6 -m venv /procbuild_env && \
+    chown -R procbuild.procbuild /procbuild_env && \
+    chown -R procbuild.procbuild /procbuild"
+
+RUN bash -c "source /procbuild_env/bin/activate && \
+    pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    curl -o scipy_proceedings.requirements.txt https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2017/requirements.txt && \
+    pip install -r scipy_proceedings.requirements.txt"
+
+USER procbuild
+
+EXPOSE 7001
+
+CMD bash -c "source /procbuild_env/bin/activate && \
+             ./update_prs && python runserver.py"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # SciPy Proceedings Builder
 
+## Quickstart: Docker Container
+
+If you already have docker engine setup, you should be able to run a version of the proceedings server by running 
+
+```bash
+docker run -it -p 7001:7001 mpacer/procbuild
+```
+
+Then, if you go to localhost:7001, you should see the server interface, and you
+can manually trigger builds by clicking the button on the right hand side.
+
+This will occupy the terminal, when you want to shut down the server and stop
+running the image you will need to type <kbd>ctrl</kbd><kbd>C</kbd>. This should
+shutdown the server and stop running the image (if you used the above command). 
+
+## General notes
+
 - Customize `runserver.py` to update this year's branch.
   For debugging, enable ``ALLOW_MANUAL_BUILD_TRIGGER``.
 - In the `scipy-conference/scipy_proceedings` repo: in the webhooks add a payload 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@ can manually trigger builds by clicking the button on the right hand side.
 
 This will occupy the terminal, when you want to shut down the server and stop
 running the image you will need to type <kbd>ctrl</kbd><kbd>C</kbd>. This should
-shutdown the server and stop running the image (if you used the above command). 
+shutdown the server and stop running the image.
+
+## Building the Docker image
+
+If you want to build the Docker image from the Dockerfile contained here you should run:
+
+```bash
+docker build -t yourname/procbuild .
+```
+
+which will create a docker image in your local repository that you can run with:
+
+```bash
+docker run -it -p 7001:7001 yourname/procbuild
+```
 
 ## General notes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 If you already have docker engine setup, you should be able to run a version of the proceedings server by running 
 
 ```bash
-docker run -it -p 7001:7001 mpacer/procbuild
+docker run -it -p 7001:7001 scipyproc/procbuild
 ```
 
 Then, if you go to localhost:7001, you should see the server interface, and you


### PR DESCRIPTION
This creates an initial Dockerfile for generating a image at mpacer/procbuild on dockerhub.

This allows people to run the server locally with the command 

```bash
docker run -it -p 7001:7001 mpacer/procbuild
```

And then to check out the site on localhost:7001.

I have included instructions in the README.md.