### PR TITLE
BuildManager

### DIFF
--- a/procbuild/__init__.py
+++ b/procbuild/__init__.py
@@ -2,8 +2,15 @@ from __future__ import print_function, absolute_import
 
 import os
 
-from .server import (app, log, get_papers, paper_queue, monitor_queue,
-    MASTER_BRANCH, ALLOW_MANUAL_BUILD_TRIGGER)
+package_dir = os.path.abspath(os.path.dirname(__file__))
+
+MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2017')
+ALLOW_MANUAL_BUILD_TRIGGER = bool(int(
+    os.environ.get('ALLOW_MANUAL_BUILD_TRIGGER', 1))
+    )
+
+#from .server import (app, log, get_papers, monitor_queue,
+#    MASTER_BRANCH, ALLOW_MANUAL_BUILD_TRIGGER)
 
 # --- Customize these variables ---
 

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -197,19 +197,25 @@ class BuildManager:
         
     @property
     def paper(self):
+        """This returns the directory from inside the papers/ directory in the PR.
+        
+        There should be one unique directory in the PR's papers/ directory that 
+        is not explicitly excluded based on values in ``excluded``.
+        
+        This will err if the there no papers are found after exclusion.
+        """
         papers = [p for p in iglob(self.build_path + '/papers/*')
                   if not any(p.endswith(e) for e in excluded)]
 
         if self.build_path is None:
             self.add_output('[X] No build path declared: %s\n' % papers)
             self.build_status = 'No build path declared'
-            raise BuildError('papers')
+            raise BuildError('paper')
         
         if len(papers) < 1:
             self.add_output('[X] No papers found: %s\n' % papers)
             self.build_status = 'Paper not found'
-            raise BuildError('papers')
-        
+            raise BuildError('paper')
         else:
             return papers[0].split('/')[-1]
     

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -91,19 +91,20 @@ class BuildManager:
                  user, 
                  branch, 
                  target, 
+                 cache,
                  master_branch='master', 
                  log=None):
         self.user = user
         self.build_output = ''
         self.status = 'fail'
         self.branch = branch
-        self.target = target
         self.master_branch = master_branch
         self.build_status = 'Build started...'
         self.build_pdf_path = ''
-        self.master_repo_path = joinp(cache(), 'scipy_proceedings')
+        self.cache = cache
+        self.master_repo_path = joinp(self.cache, 'scipy_proceedings')
         self.build_timestamp = time.strftime('%d/%m %H:%M')
-        self.target_path = joinp(cache(), '%s.pdf' % target)
+        self.target_path = joinp(self.cache, f'{target!s}.pdf')
         self.build_path = None
         
         data_filenames = ['IEEEtran.cls', 

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -143,7 +143,7 @@ class BuildManager:
         self.add_output(output)
         
         if errcode:
-            self.add_output('[X] Error code %d ' % errcode)
+            self.add_output('[X] Could not get build tools, errcode: %d ' % errcode)
             raise BuildError("get_build_tools")
         
         self._remove_papers_dir()
@@ -159,7 +159,7 @@ class BuildManager:
         self.add_output(output)
 
         if errcode:
-            self.add_output('[X] Error code %d ' % errcode)
+            self.add_output('[X] Could not clean papers/ build tools, errcode: %d ' % errcode)
             raise BuildError("remove_papers_dir")
 
     def _checkout_paper_repo(self):
@@ -170,7 +170,7 @@ class BuildManager:
         self.add_output(output)
         
         if errcode:
-            self.add_output('[X] Error code %d\n' % errcode)
+            self.add_output('[X] Could not checkout user\'s repo, errcode: %d\n' % errcode)
             self.build_status = 'Failed to check out paper'
             raise BuildError('checkout_paper_repo')
 
@@ -183,7 +183,7 @@ class BuildManager:
                                 f'{self.master_repo_path}/. {self.build_path}')
         self.add_output(output)
         if errcode:
-            self.add_output('[X] Error code %d\n' % errcode)
+            self.add_output('[X] Could not relocate build tools, errcode: %d\n' % errcode)
             self.build_status = 'Could not move build tools to temp directory'
             raise BuildError('relocate_build_tools')
 

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -9,7 +9,7 @@ import time
 import random
 
 from os.path import join as joinp
-from glob import glob, iglob
+from glob import iglob
 
 excluded = ['vanderwalt', '00_vanderwalt', 'jane_doe', 'bibderwalt', '00_intro']
 

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -144,6 +144,21 @@ class BuildManager(object):
         if errcode:
             self.add_output('[X] Error code %d ' % errcode)
             raise BuildError("get_build_tools")
+        
+        self.remove_papers_dir()
+        
+    
+    def remove_papers_dir(self):
+        """ this command will remove the papers dir from the build_tools dir
+        
+        """
+        errcode, output = shell('rm -rf scipy_proceedings/papers')
+        
+        self.add_output(output)
+
+        if errcode:
+            self.add_output('[X] Error code %d ' % errcode)
+            raise BuildError("remove_papers_dir")
 
     def checkout_paper_repo(self):
         self.add_output('[*] Check out paper repository...\n')

--- a/procbuild/builder.py
+++ b/procbuild/builder.py
@@ -86,6 +86,17 @@ class BuildError(Exception):
 
         
 class BuildManager:
+    """
+    
+    Parameters
+    ----------
+    user: str; name of GitHub user
+    branch: str; name of git branch on user's PR
+    target: str; string representation of integer for which paper to build
+    cache: str; cache directory in which the build tools and final paper live
+    master_branch: str; git branch for build tools 
+    log: function; logging function
+    """
     
     def __init__(self, 
                  user, 

--- a/procbuild/pr_list/__init__.py
+++ b/procbuild/pr_list/__init__.py
@@ -9,10 +9,26 @@ import codecs
 from os.path import join as joinp
 
 from ..builder import cache
+from ..utils import file_age, log
 
 __all__ = ['fetch_PRs', 'update_papers']
 
 pr_list_file = joinp(cache(), 'pr_info.json')
+
+def outdated_pr_list(expiry=1):
+    if not os.path.isfile(pr_list_file):
+        update_papers()
+    elif file_age(pr_list_file) > expiry:
+        log("Updating papers...")
+        update_papers()
+
+def get_pr_info():
+    with io.open(pr_list_file) as f:
+        pr_info = json.load(f)
+    return pr_info
+
+def get_papers():
+    return [(str(n), pr) for n, pr in enumerate(get_pr_info())]
 
 
 def fetch_PRs(user, repo, state='open'):

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -194,9 +194,8 @@ def _build_worker(nr):
 
 
     def build_and_log(*args, **kwargs):
-        status = build_paper(*args, **kwargs)
-        # build_manager = BuildManager(*args, **kwargs)
-        # status = build_manager.build_paper()
+        build_manager = BuildManager(*args, **kwargs)
+        status = build_manager.build_paper()
         with io.open(status_log, 'wb') as f:
             json.dump(status, codecs.getwriter('utf-8')(f), ensure_ascii=False)
 

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -10,7 +10,6 @@ import inspect
 import codecs
 
 from os.path import join as joinp
-from datetime import datetime, timedelta
 from glob import glob
 from flask import Flask
 
@@ -21,6 +20,7 @@ from . import ALLOW_MANUAL_BUILD_TRIGGER, MASTER_BRANCH
 from .builder import BuildManager, cache, base_path 
 from .pr_list import update_papers, pr_list_file
 
+from .utils import file_age, status_file, log
 
 def get_pr_info():
     with io.open(pr_list_file) as f:
@@ -38,33 +38,6 @@ def outdated_pr_list(expiry=1):
     elif file_age(pr_list_file) > expiry:
         log("Updating papers...")
         update_papers()
-
-
-def file_age(fn):
-    """Return the age of file `fn` in minutes.  Return None is the file does
-    not exist.
-    """
-    if not os.path.exists(fn):
-        return None
-
-    modified = datetime.fromtimestamp(os.path.getmtime(fn))
-    delta = datetime.now() - modified
-
-    return delta.seconds / 60
-
-
-def log(message):
-    print(message)
-    with io.open(joinp(os.path.dirname(__file__), '../flask.log'), 'a') as f:
-        time_of_message = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()) 
-        cf = inspect.currentframe().f_back
-        where = '{}:{}'.format(cf.f_code.co_filename, cf.f_lineno)
-        f.write(" ".join([time_of_message, where, message, '\n']))
-        f.flush()
-
-
-def status_file(nr):
-    return joinp(cache(), str(nr) + '.status')
 
 
 def status_from_cache(nr):

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -17,27 +17,9 @@ from multiprocessing import Process, Queue
 
 
 from . import ALLOW_MANUAL_BUILD_TRIGGER, MASTER_BRANCH 
-from .builder import BuildManager, cache, base_path 
-from .pr_list import update_papers, pr_list_file
-
+from .builder import BuildManager, cache, base_path
+from .pr_list import outdated_pr_list, get_papers, get_pr_info
 from .utils import file_age, status_file, log
-
-def get_pr_info():
-    with io.open(pr_list_file) as f:
-        pr_info = json.load(f)
-    return pr_info
-
-
-def get_papers():
-    return [(str(n), pr) for n, pr in enumerate(get_pr_info())]
-
-
-def outdated_pr_list(expiry=1):
-    if not os.path.isfile(pr_list_file):
-        update_papers()
-    elif file_age(pr_list_file) > expiry:
-        log("Updating papers...")
-        update_papers()
 
 
 def status_from_cache(nr):

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -16,7 +16,7 @@ from flask import Flask
 
 from multiprocessing import Process, Queue
 
-from .builder import build as build_paper, cache, base_path
+from .builder import build as build_paper, BuildManager, cache, base_path 
 from .pr_list import update_papers, pr_list_file
 
 MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2017')
@@ -195,6 +195,8 @@ def _build_worker(nr):
 
     def build_and_log(*args, **kwargs):
         status = build_paper(*args, **kwargs)
+        # build_manager = BuildManager(*args, **kwargs)
+        # status = build_manager.build_paper()
         with io.open(status_log, 'wb') as f:
             json.dump(status, codecs.getwriter('utf-8')(f), ensure_ascii=False)
 

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -16,7 +16,7 @@ from flask import Flask
 
 from multiprocessing import Process, Queue
 
-from .builder import build as build_paper, BuildManager, cache, base_path 
+from .builder import BuildManager, cache, base_path 
 from .pr_list import update_papers, pr_list_file
 
 MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2017')
@@ -200,7 +200,8 @@ def _build_worker(nr):
             json.dump(status, codecs.getwriter('utf-8')(f), ensure_ascii=False)
 
     p = Process(target=build_and_log,
-                kwargs=dict(user=pr['user'], branch=pr['branch'],
+                kwargs=dict(user=pr['user'],
+                            branch=pr['branch'],
                             master_branch=MASTER_BRANCH,
                             target=nr, log=log))
     p.start()

--- a/procbuild/server.py
+++ b/procbuild/server.py
@@ -16,12 +16,10 @@ from flask import Flask
 
 from multiprocessing import Process, Queue
 
+
+from . import ALLOW_MANUAL_BUILD_TRIGGER, MASTER_BRANCH 
 from .builder import BuildManager, cache, base_path 
 from .pr_list import update_papers, pr_list_file
-
-MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2017')
-ALLOW_MANUAL_BUILD_TRIGGER = bool(int(os.environ.get(
-    'ALLOW_MANUAL_BUILD_TRIGGER', 1)))
 
 
 def get_pr_info():

--- a/procbuild/utils.py
+++ b/procbuild/utils.py
@@ -1,0 +1,37 @@
+import os
+import inspect
+import io
+import time
+
+from datetime import datetime, timedelta
+from os.path import join as joinp
+
+from . import package_dir
+from .builder import cache
+
+def log(message):
+    print(message)
+    with io.open(joinp(package_dir, '../flask.log'), 'a') as f:
+        time_of_message = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()) 
+        cf = inspect.currentframe().f_back
+        where = f'{cf.f_code.co_filename}:{cf.f_lineno}'
+        f.write(" ".join([time_of_message, where, message, '\n']))
+        f.flush()
+
+
+def file_age(fn):
+    """Return the age of file `fn` in minutes.  Return None is the file does
+    not exist.
+    """
+    if not os.path.exists(fn):
+        return None
+
+    modified = datetime.fromtimestamp(os.path.getmtime(fn))
+    delta = datetime.now() - modified
+
+    return delta.seconds / 60
+
+    
+def status_file(nr):
+    return joinp(cache(), str(nr) + '.status')
+    


### PR DESCRIPTION
I want to make the build procedure more isolated chunks that have specific purposes so that they could A: be tested separately and B: understood separately. I think there are also a number of instances where we're issuing shell commands that we could do from within python. (edited)

This is the first step in refactoring the actual builder.

Right now, this is just a WIP because for some reason despite using the
same code, it seems to be pulling in the entire upstream repo (including
all of its papers) rather than just the proceedings build tools. I don't
know why it works for the standard build script but not the main build
script.

I'm stopping for now because I think I overran my github rate limit for the next couple of hours.