### PR TITLE
update year of branch to 2018

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN bash -c "python3.6 -m venv /procbuild_env && \
 RUN bash -c "source /procbuild_env/bin/activate && \
     pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    curl -o scipy_proceedings.requirements.txt https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2017/requirements.txt && \
+    curl -o scipy_proceedings.requirements.txt https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2018/requirements.txt && \
     pip install -r scipy_proceedings.requirements.txt"
 
 USER procbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN bash -c "python3.6 -m venv /procbuild_env && \
 RUN bash -c "source /procbuild_env/bin/activate && \
     pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    curl -o scipy_proceedings.requirements.txt https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2018/requirements.txt && \
-    pip install -r scipy_proceedings.requirements.txt"
+    pip install -r <(curl --silent https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2018/requirements.txt)"
 
 USER procbuild
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This includes some packages on pypi which we'll install with `pip`. The easiest
 way to do this is by pulling down the latest version of the file with `curl`:
 
 ```
-pip install -r <(curl https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2017/requirements.txt)
+pip install -r <(curl https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2018/requirements.txt)
 ```
 
 Additionally, you will need to install a version of LaTeX and some external

--- a/procbuild/__init__.py
+++ b/procbuild/__init__.py
@@ -2,5 +2,5 @@ import os
 
 package_path = os.path.abspath(os.path.dirname(__file__))
 
-MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2017')
+MASTER_BRANCH = os.environ.get('MASTER_BRANCH', '2018')
 ALLOW_MANUAL_BUILD_TRIGGER = bool(int(os.environ.get('ALLOW_MANUAL_BUILD_TRIGGER', 1)))

--- a/runserver.py
+++ b/runserver.py
@@ -6,7 +6,7 @@ from procbuild.server import app
 from waitress import serve
 
 # -- SERVER CONFIGURATION -- (can be overridden from shell)
-config = (('MASTER_BRANCH', '2017'),
+config = (('MASTER_BRANCH', '2018'),
           ('ALLOW_MANUAL_BUILD_TRIGGER', '1'),
           ('PORT', '7001'))
 


### PR DESCRIPTION
Updates the year of the branch to 2018, to match the current default branch at https://github.com/scipy-conference/scipy_proceedings