### PR TITLE
Setup Travis to trigger docker builds and DockerHub & Heroku deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+cache/
+__pycache__
+flask.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,27 @@
+sudo: required
 language: python
-
+services:
+- docker
 python:
-  - 3.6
-install: 
-  - pip install --upgrade setuptools pip  
-  - pip install -r requirements.txt
-  - pip install -r <(curl --silent https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2018/requirements.txt)
+- 3.6
+install:
+- pip install --upgrade setuptools pip
+- pip install -r requirements.txt
+- pip install -r <(curl --silent https://raw.githubusercontent.com/scipy-conference/scipy_proceedings/2018/requirements.txt)
 script:
-  - pytest
-
-  
+- pytest
+- docker build -t scipyproc/procbuild .
+- docker tag scipyproc/procbuild scipyproc/procbuild:$(git rev-parse HEAD).$MASTER_BRANCH
+- docker tag scipyproc/procbuild registry.heroku.com/procbuild/web
+deploy:
+  provider: script
+  script:
+  - bash docker_push
+  - bash heroku_push
+  on:
+    branch: master
+env:
+  global:
+  - secure: hZtAMITDimlE+xS1O1uY4HV9+NnCEATiuj2KdeZubnAESgQEIy/nMuES0uMOgabWhW0ziSKx3xGZlW4KVGVVtDNLJHT527P9bhGWmvzfI2XyeukYVLmOmXYURUNatPmH4Ll7tni+NRnMMKAbPsmlH20a2zhOX9KaSy/zVrHLv+k=
+  - secure: isINB6dDcGeEWB1qbUgTP/J57FiRSAxsbTjKKmv6iz0AiUldSAP9NUBhvAY7JN5tLvDfxVIJH4ip7yJNlGgP2iAXG4m+Oy05+qbetyF1X3VWlKi5widV++ni2+1im4ZX/7eREY2DiC1DEUi3Vy7geu8kFbWrQhEKvXPXIhyrVik=
+  - secure: fKXsUDFFHpZgjdiG4w9nLwIa2gZvnBtbqeiVLK1BE6wj9rim8LYBL381ydv/4IzdfprvgxTeCr3sWJyRz5UPJbj+qa2MbkkLq2AEL4t49bpoRBQfT1W+aFP+OiV7uOgiWAjD4tvdetEr5jEjPzlGtxDLVlWdOQ/JU7OPEGAibZA=

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ docker run -it -p 7001:7001 yourname/procbuild
 
 ## Pushing the Docker image to SciPy's DockerHub repository
 
-Before you push the image, you need to make sure you remove the cache.
+We have files listed in `.dockerignore` that should not be included in the repository. Otherwise all other files in the directory will be included.
+
+Before you begin the following, you should be sure to set the `MASTER_BRANCH` evironment variable. 
 
 ```bash
-rm -rf cache
+export MASTER_BRANCH=2018
 ```
 
 If you want to push the image to DockerHub so that it can be publicly available you would need to assign it the `scipyproc/procbuild` tag. 
@@ -48,14 +50,14 @@ docker build -t scipyproc/procbuild .
 You should also increment the version number. You do this by adding a new tag.
 
 ```bash
-docker tag scipyproc/procbuild scipyproc/procbuild:x.y 
+docker tag scipyproc/procbuild scipyproc/procbuild:x.y.$MASTER_BRANCH
 ```
 
 Then you should push these up to the DockerHub repository (the default repository). This should push up both the latest version and the version number.
 
 ```bash
 docker push scipyproc/procbuild:latest
-docker push scipyproc/procbuild:x.y
+docker push scipyproc/procbuild:x.y.$MASTER_BRANCH
 ```
 
 ## Pushing the Docker image to Heroku's repository

--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ Then you need to push it to the heroku registry
 docker push registry.heroku.com/procbuild/web
 ```
 
+## Working with Travis
+
+[Travis](https://travis-ci.org/scipy-conference/procbuild) is our continuous
+integration system. We use it to run tests (via `pytest`) and to build and
+deploy our docker images to DockerHub and Heroku, which backs the [procbuild.scipy.org](http://procbuild.scipy.org) website.
+
+### Updating the year
+
+When running Travis, we need to know the `MASTER_BRANCH` so that we can create
+appropriate docker image numbers.
+
+```bash
+travis env set MASTER_BRANCH $MASTER_BRANCH --public
+```
+
+### What should travis do when you make a PR?
+
+We have set Travis up to attempt to build a Docker image from the Dockerfile on 
+every PR and commit.
+
+If you want to change this behaviour, you will need to change the top-level
+`script` field in `.travis.yml`. But, you will also need to change the scripts
+in the `build_scripts/` directory to handle whatever changes you make.
+
+### What should travis do when `master` changes?
+
+We have set Travis up to deploy and push the docker images it builds to
+[DockerHub](https://hub.docker.com/r/scipyproc/procbuild/) and to 
+[Heroku's Docker registry](https://devcenter.heroku.com/articles/container-registry-and-runtime#logging-in-to-the-registry).
+
+This deploy script should be triggered every time any commit is made to master.
+This includes both PRs being merged into master and commits made directly to
+master.
+
 ## General notes
 
 - Customize `runserver.py` to update this year's branch.

--- a/build_scripts/docker_push
+++ b/build_scripts/docker_push
@@ -1,3 +1,4 @@
 #!/bin/bash
 echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 docker push scipyproc/procbuild:$(git rev-parse HEAD).$MASTER_BRANCH
+docker push scipyproc/procbuild:latest

--- a/build_scripts/docker_push
+++ b/build_scripts/docker_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+docker push scipyproc/procbuild:$(git rev-parse HEAD).$MASTER_BRANCH

--- a/build_scripts/heroku_push
+++ b/build_scripts/heroku_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "$HEROKU_TOKEN" | docker login -u _ --password-stdin registry.heroku.com
+docker push registry.heroku.com/procbuild/web


### PR DESCRIPTION
This creates the necessary infrastructure to automatically build a docker image with every PR that comes in.

Additionally, once the PR is merged to master, travis should automatically deploy the resulting images to both DockerHub and Heroku.