### PR TITLE
BUG: stop keying papers with enumerate

### DIFF
--- a/procbuild/listener.py
+++ b/procbuild/listener.py
@@ -11,26 +11,26 @@ from zmq.asyncio import Context
 from . import MASTER_BRANCH
 from .message_proxy import OUT
 from .utils import file_age, log
-from .pr_list import get_pr_info, status_file, cache
+from .pr_list import get_pr_info, status_file, cache, get_papers
 from .builder import BuildManager
 
 
 class Listener:
     """ Listener class for defining zmq sockets and maintaining a build queue.
-    
+
     Attributes
     ----------
-    ctx : zmq.asyncio.Context 
+    ctx : zmq.asyncio.Context
         main context for the listener class
     socket : zmq.socket
-        the socket for listening to 
+        the socket for listening to
     queue : asyncio.Queue
         the queue for holding the builds
     dont_build : set
         unique collection of PRs currently in self.queue
         Note: Only modify self.dont_build within synchronous blocks.
     """
-    
+
     def __init__(self):
         self.ctx = Context.instance()
         target_set = {'build_queue'}
@@ -39,7 +39,7 @@ class Listener:
         self.socket.connect(OUT)
         for target in target_set:
             self.socket.setsockopt(zmq.SUBSCRIBE, target.encode('utf-8'))
-        
+
         self.queue = asyncio.Queue()
         self.dont_build = set()
 
@@ -52,112 +52,112 @@ class Listener:
             target, raw_payload = msg
             payload = json.loads(raw_payload.decode('utf-8'))
             paper_nr = payload.get('build_paper', None)
-            
+
             if self.paper_too_young(paper_nr) or self.paper_in_queue(paper_nr):
                 continue
             self.dont_build.add(paper_nr)
             await self.queue.put(paper_nr)
-    
-    def paper_too_young(self, nr):
-        """Check the age of a PR's status_file based on its number. 
-        
+
+    def paper_too_young(self, fork):
+        """Check the age of a PR's status_file based on its number.
+
         Parameters
         ----------
-        nr : int
-            the number of the PR in order of receipt
+        fork : str
+            the combined user-branch name
         """
-        age = file_age(status_file(nr))
+        age = file_age(status_file(fork))
         min_wait = 0.5
         too_young = (age is not None) and (age <= min_wait)
         if too_young:
-            log(f"Did not build paper {nr}--recently built.")
+            log(f"Did not build paper {fork}--recently built.")
         return too_young
-    
-    def paper_in_queue(self, nr):
+
+    def paper_in_queue(self, fork):
         """Check whether the queue currently contains a build request for a PR.
-        
+
         Parameters
-        ---------- 
-        nr : int
-            the number of the PR to check
+        ----------
+        fork : str
+            the combined user-branch name
         """
-        in_queue = nr in self.dont_build
+        in_queue = fork in self.dont_build
         if in_queue:
-            log(f"Did not queue paper {nr}--already in queue.")
+            log(f"Did not queue paper {fork}--already in queue.")
         return in_queue
-        
-    def report_status(self, nr):
-        """prints status notification from status_file for paper `nr` 
-        
+
+    def report_status(self, fork):
+        """prints status notification from status_file for paper `fork`
+
         Parameters
-        ---------- 
-        nr : int
-            the number of the PR to check
+        ----------
+        fork : str
+            the combined user-branch name
         """
-        with io.open(status_file(nr), 'r') as f:
+        with io.open(status_file(fork), 'r') as f:
             status = json.load(f)['status']
 
         if status == 'success':
-            print(f"Completed build for paper {nr}.")
-        else: 
-            print(f"Paper for {nr} did not build successfully.")
+            print(f"Completed build for paper {fork}.")
+        else:
+            print(f"Paper for {fork} did not build successfully.")
 
 
     async def queue_builder(self, loop=None):
         """Manage queue and trigger builds, report results.
-        
+
         loop : asyncio.loop
             the loop on which to be running these tasks
         """
         while True:
             # await an item from the queue
-            nr = await self.queue.get()
+            fork = await self.queue.get()
             # launch subprocess to build item
             with ThreadPoolExecutor(max_workers=1) as e:
-                await loop.run_in_executor(e, self.build_and_log, nr)
-                self.dont_build.remove(nr)
-                self.report_status(nr)
-                
-    def paper_log(self, nr, record):
+                await loop.run_in_executor(e, self.build_and_log, fork)
+                self.dont_build.remove(fork)
+                self.report_status(fork)
+
+    def paper_log(self, fork, record):
         """Writes status to PR's log file
-        
+
         Parameters
-        ---------- 
-        nr : int
-            the number of the PR to check
+        ----------
+        fork : str
+            the combined user-branch name
         record : dict
             the dictionary content to be written to the log
         """
-        status_log = status_file(nr)
+        status_log = status_file(fork)
         with io.open(status_log, 'wb') as f:
             json.dump(record, codecs.getwriter('utf-8')(f), ensure_ascii=False)
-    
-    def build_and_log(self, nr):
+
+    def build_and_log(self, fork):
         """Builds paper for PR number and logs the resulting status
-        
+
         Parameters
         ----------
-        nr : int
-            the number of the PR to check
+        fork : str
+            the combined user-branch name
         """
-        pr_info = get_pr_info()
-        pr = pr_info[int(nr)]
+        papers = get_papers()
+        pr = papers[fork]
 
         build_record = {'status': 'fail',
                         'data': {'build_status': 'Building...',
                                  'build_output': 'Initializing build...',
                                  'build_timestamp': ''}}
-        self.paper_log(nr, build_record)
+        self.paper_log(fork, build_record)
 
         build_manager = BuildManager(user=pr['user'],
                                      branch=pr['branch'],
                                      cache=cache(),
                                      master_branch=MASTER_BRANCH,
-                                     target=nr, 
+                                     target=fork,
                                      log=log)
 
         status = build_manager.build_paper()
-        self.paper_log(nr, status)
+        self.paper_log(fork, status)
 
 
 if __name__ == "__main__":

--- a/procbuild/pr_list/__init__.py
+++ b/procbuild/pr_list/__init__.py
@@ -31,30 +31,29 @@ def fork_name(user, branch):
 def status_from_cache(fork):
     papers = get_papers()
     if fork == '*':
-        forks = papers.keys()
-        status_files = [status_file(fork) for fork in forks]
+        keys = papers.keys()
+        status_files = [status_file(key) for key in keys]
     else:
-        forks = [fork]
+        keys = [fork]
         status_files = [status_file(fork)]
 
     data = {}
 
-    for fork, fp in zip(forks, status_files):
+    for key, fp in zip(keys, status_files):
 
-        if fork in papers:
-            data[fork] = {'status': 'fail',
+        if key in papers:
+            data[key] = {'status': 'fail',
                       'data': {'build_output': 'No build info'}}
         else:
-            data[fork] = {'status': 'fail',
+            data[key] = {'status': 'fail',
                        'data': {'build_output': 'Invalid paper'}}
 
         if os.path.exists(fp):
             with io.open(fp, 'r') as f:
                 try:
-                    data[fork] = json.load(f)
+                    data[key] = json.load(f)
                 except ValueError as e:
                     pass
-
     # Unpack status if only one record requested
     if fork != '*':
         return {fork: data[fork]}

--- a/procbuild/submitter.py
+++ b/procbuild/submitter.py
@@ -6,43 +6,43 @@ from .message_proxy import IN
 
 class BuildRequestSubmitter:
     """Class for submitting build requests to zmq socket.
-    
+
     Parameters
     ----------
     verbose : bool, optional
         whether to print a message when submitting with builder (default is False)
-        
+
     Attributes
     ----------
     verbose
     socket : zmq.socket, socket for pushing messages out
     """
-    
+
     def __init__(self, verbose=False):
         ctx = zmq.Context()
         self.socket = ctx.socket(zmq.PUSH)
         self.socket.connect(IN)
         self.verbose = verbose
-    
-    def construct_message(self, nr):
+
+    def construct_message(self, fork):
         """Creates message to be sent on zmq socket.
-        
+
         Parameters
         ----------
         nr : int
             the number of the PR in order of receipt
         """
-        return ['build_queue', json.dumps({'build_paper': nr})]
-        
-    def submit(self, nr):
+        return ['build_queue', json.dumps({'build_paper': fork})]
+
+    def submit(self, fork):
         """Submits message to zmq socket
-        
+
         Parameters
         ----------
         nr : int
             the number of the PR in order of receipt
         """
-        message = self.construct_message(nr)
+        message = self.construct_message(fork)
         if self.verbose:
             print('Submitting:', message)
 

--- a/procbuild/templates/index.html
+++ b/procbuild/templates/index.html
@@ -110,7 +110,7 @@ $(document).ready(function() {
 
 
 <div class="paper_list">
-{% for n, p in papers %}
+{% for n, p in papers.items() %}
 <div class="paper">
 
   [


### PR DESCRIPTION
procbuild assigns a unique identifier to each paper that it uses
to retrieve the paper status and pdf. Currently, this is done
by enumerating open PRs, which works fine until a PR is opened
or closed, at which point all of the IDs are off by one. This
commit replaces the integer keys with one composed of the user
and branch name, which is hopefully close enough to unique.
Closes #18.

Note: the commit is not as large as the diff seems to indicate.
A lot of the file changes are from my editor auto-deleting the
trailing whitespace on a bunch of lines.