### PR TITLE
BUG: replace slashes in branch names

### DIFF
--- a/procbuild/pr_list/__init__.py
+++ b/procbuild/pr_list/__init__.py
@@ -26,7 +26,7 @@ def status_file(fork):
     return joinp(cache(), fork + '.status')
 
 def fork_name(user, branch):
-    return '-'.join((user, branch))
+    return '-'.join((user, branch)).replace('/', '-').replace('\\', '-')
 
 def status_from_cache(fork):
     papers = get_papers()


### PR DESCRIPTION
In 5b09e20ddaa9f35569f50fbc22d4301b5281dbcd, papers were keyed
by a combination of user and branch name. In git, branch names
are allowed to have slashes, which causes issues when you try
to use a branch name for a filepath or URL.