### PR TITLE
Fix comprehension syntax.

### DIFF
--- a/build_papers.py
+++ b/build_papers.py
@@ -9,7 +9,7 @@ import sys
 if len(sys.argv) > 1:
     to_build = sys.argv[1:]
 else:
-    to_build = [nr for nr, info in get_papers()]
+    to_build = [nr for nr, info in get_papers().items()]
 
 submitter = BuildRequestSubmitter(verbose=True)
 for p in to_build:


### PR DESCRIPTION
Hi! I'm using this Docker image locally to build my paper drafts and noticed that the `build_papers.py` script wasn't working. The result of `get_papers()` is a dictionary, so this comprehension needs to iterate over `get_papers().items()`.

Alternatively we could just replace this line with `to_build = list(get_papers().keys())`.