### PR TITLE
BUG: clone repo using real repo name

### DIFF
--- a/procbuild/listener.py
+++ b/procbuild/listener.py
@@ -150,6 +150,7 @@ class Listener:
         self.paper_log(fork, build_record)
 
         build_manager = BuildManager(user=pr['user'],
+                                     repo=pr['repo'],
                                      branch=pr['branch'],
                                      cache=cache(),
                                      master_branch=MASTER_BRANCH,

--- a/procbuild/pr_list/__init__.py
+++ b/procbuild/pr_list/__init__.py
@@ -143,8 +143,13 @@ def update_papers():
 
     pr_info = []
     for p in PRs:
-        pr_info.append({'user': p['head']['user']['login'], 'title': p['title'],
-                        'branch': p['head']['ref'], 'url': p['html_url']})
+        pr_info.append({
+            'user': p['head']['user']['login'],
+            'repo': p['head']['repo']['name'],
+            'title': p['title'],
+            'branch': p['head']['ref'],
+            'url': p['html_url']}
+        )
 
     with io.open(get_pr_list_file(), 'wb') as f:
         json.dump(pr_info, codecs.getwriter('utf-8')(f), ensure_ascii=False)


### PR DESCRIPTION
In the user PR code cloning logic, we currently assume that the repo name is always scipy_proceedings. This causes procbuild to fail when a user forks our repo and changes the name, e.g. to scipy_proceedings_2023. This changes the PR listing logic to fetch and return the actual repo name, and then passes that through the BuildManager into the clone url function.

xref https://github.com/scipy-conference/scipy_proceedings/pull/831