### PR TITLE
BUG: add texlive-font-utils to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GID_PROCBUILD=1006
 RUN apt-get update && \
     apt-get install -y build-essential python3 python3-dev python3-wheel python3-venv git curl \
     texlive-latex-base texlive-publishers texlive-fonts-recommended  \
-    texlive-latex-extra texlive-bibtex-extra texlive-science && \
+    texlive-latex-extra texlive-bibtex-extra texlive-science texlive-font-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     groupadd -g ${GID_PROCBUILD} procbuild && \


### PR DESCRIPTION
This is necessary for pdflatex to include .eps vector images into papers.

xref https://github.com/scipy-conference/scipy_proceedings/pull/824